### PR TITLE
[fix] Arregla configuración de sass-loader

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -60,7 +60,7 @@
 //  55. Top Bar
 //  56. Xy Grid
 
-@import '~foundation-sites/scss/util/util';
+@import 'util/util';
 
 // 1. Global
 // ---------

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,5 +1,5 @@
 @import 'settings';
-@import '~foundation-sites/scss/foundation';
+@import 'foundation';
 
 //todo: incluir solo lo que necesitamos
 @include foundation-everything;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,15 @@ module.exports = {
 				use: [
 					'style-loader',
 					'css-loader',
-					'sass-loader'
+					{
+						loader: 'sass-loader',
+						options: {
+							webpackImporter: false,
+							sassOptions: {
+								includePaths: [path.resolve(__dirname, 'node_modules/foundation-sites/scss')],
+							},
+						}
+					}
 				]
 			},
 			{


### PR DESCRIPTION
Un pequeño cambio que sigue las [recomendaciones](https://get.foundation/sites/docs/sass.html) de `foundation-sites`. El importer de webpack parece que no permite incluir paths en `node_modules`. Un pequeño cambio para no tener que hacer:

```sass
@import '~foundation-sites/scss/foundation'
```
Y poder hacer:

```sass
@import 'foundation'
```

Los imports de foundation (como el de `_settings.scss`) deberían funcionar sin ninguna modificación.