### PR TITLE
[fix] Workflow no tiene linux/arm/v6

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,6 +16,10 @@ jobs:
                   username: ${{ secrets.CR_USER }}
                   password: ${{ secrets.CR_PAT }}
             - 
+              uses: docker/setup-qemu-action@v1
+              with:
+                  platforms: all
+            - 
               name: Create builder
               uses: docker/setup-buildx-action@v1
 
@@ -32,16 +36,13 @@ jobs:
     deploy_to_rpi:
         name: Pull image from GHCR and run with docker-compose
         needs: build_dev_pi_image
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         env:
             SSH_HOST: ${{ secrets.SSH_HOST }}
             SSH_USER: ${{ secrets.SSH_USER }}
             SSH_PORT: ${{ secrets.SSH_PORT }}
         steps:
             - uses: actions/checkout@v2
-            - 
-              name: Set DOCKER_HOST
-              run: echo "::set-env name=DOCKER_HOST::ssh://$SSH_USER@$SSH_HOST:$SSH_PORT"
             - 
               name: Set SSH client
               env:
@@ -57,6 +58,9 @@ jobs:
                   echo "$SSH_HOST $HOST_KEY" > /etc/ssh/ssh_known_hosts
                   echo ::set-env name=SSH_AUTH_SOCK::$SSH_AUTH_SOCK
                   echo ::set-env name=SSH_AGENT_PID::$SSH_AGENT_PID
+            - 
+              name: Set DOCKER_HOST
+              run: echo "::set-env name=DOCKER_HOST::ssh://$SSH_USER@$SSH_HOST:$SSH_PORT"
             - 
               name: Login to GHCR
               uses: docker/login-action@v1


### PR DESCRIPTION
Este PR es una continuación del #12

Hacia falta agregar `qemu`, de manera local  no había problemas porque mis contenedores usan mi instancia de docker que si tiene `qemu`. Uno de los trabajos estaba usando Ubuntu 18.04, debería ser Ubuntu 20.04 (por docker-compose). Si `docker-compose` no funciona correctamente es probable que necesitemos instalarlo sobre la instancia de Github Actions.

Espero que sea el último PR sobre este workflow, sino toca investigar más a fondo que es lo que está pasando.