### PR TITLE
[fix] Lista de equipos incorrecta en el workflow de rPI

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -55,7 +55,7 @@ jobs:
                   chmod 600 $HOME/.ssh/id_rsa
                   eval $(ssh-agent)
                   ssh-add $HOME/.ssh/id_rsa
-                  echo "$SSH_HOST $HOST_KEY" > /etc/ssh/ssh_known_hosts
+                  echo "$SSH_HOST $HOST_KEY" > $HOME/.ssh/known_hosts
                   echo ::set-env name=SSH_AUTH_SOCK::$SSH_AUTH_SOCK
                   echo ::set-env name=SSH_AGENT_PID::$SSH_AGENT_PID
             - 


### PR DESCRIPTION
Está es una continuación de #13 y #12

Github Actions se queja de permisos al escribir sobre `/etc/ssh/ssh_known_hosts` mientras que la herramienta en local para probar las actions [act](https://github.com/nektos/act) no se lleva bien con `$HOME/.ssh/`. `act` corre bajo root y el `$HOME` está puesto a `/github/home` sin embargo SSH sigue buscando los hosts en `/root/.ssh/known_hosts`. Esperemos que Github Actions haga lo correcto...