### PR TITLE
[fix] Recrear contenedores con docker-compose

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,6 +20,9 @@ jobs:
             - name: Create builder
               uses: docker/setup-buildx-action@v1
 
+            - uses: satackey/action-docker-layer-caching@v0.0.8
+                  continue-on-error: true
+
             - name: Build and push docker image
               uses: docker/build-push-action@v2
               with:


### PR DESCRIPTION
Continuación de #14, #13, #12, #11...

El archivo de configuración de docker tiene un nombre para el contenedor de webpack. Al intentar levantar un contenedor con la nueva imagen, hay una colisión entre el viejo contenedor y el nuevo contenedor porque usan el mismo nombre. Con la opción `--force-recreate` docker-compose no debería tener problemas.

También he agregado una pequeña optimización a la build inicial. Lo que tarda mucho en la build es descargar la imagen y extraerla. Será mejor una vez que tenga un nuevo rPI.