### PR TITLE
[fix] Agrega acción de checkout

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,6 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         name: Update docker image and launch new containers
         steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
             - name: Login to GHCR
               uses: docker/login-action@v1
               with:


### PR DESCRIPTION
La documentación de [build-push-action](https://github.com/docker/build-push-action) dice que no es necesario hacer checkout del código.

> By default, this action uses the Git context so you don't need to use the actions/checkout action to checkout the repository because this will be done directly by buildkit.

Sin embargo, el workflow no encuentra el Dockerfile, así que pongo en duda que realmente haga checkout.... De todas maneras en los ejemplos usan el action de checkout...