### PR TITLE
[fix] Ruta equivocada en el cliente y servidor de desarrollo roto

### DIFF
--- a/server/base.jsx
+++ b/server/base.jsx
@@ -68,8 +68,4 @@ router.get('/', (req, res) => {
         });
 });
 
-router.get('/favicon.ico', (req, res) => {
-    res.redirect('/img/favicon.png');
-});
-
 export default router;

--- a/src/components/Layout/News/index.jsx
+++ b/src/components/Layout/News/index.jsx
@@ -15,7 +15,7 @@ export default () => {
     let dispatch = useDispatch();
 
     useEffect(() => {
-        dispatch(fetchNews('http://localhost:8080/api/news'));
+        dispatch(fetchNews('/api/news'));
     }, []);
 
     return (

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -6,7 +6,7 @@ import createStore from './store';
 import RoutesConfig from './routes';
 
 const scriptTag = document.getElementById('initialState');
-const initialState = scriptTag ? JSON.parse(scriptTag.innerHTML) : {};
+const initialState = scriptTag || JSON.parse(scriptTag.innerHTML || {});
 
 const store = createStore(initialState);
 


### PR DESCRIPTION
No hay mucho más que decir, había una ruta con `localhost` y se la he quitado. El estado inicial se estaba cargando incorrectamente en desarrollo, no lo había probado sin SSR después de los últimos cambios.